### PR TITLE
Use minideb for a smaller image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM debian:latest
+FROM bitnami/minideb:jessie
 MAINTAINER johanneskoester "johannes.koester@tu-dortmund.de"
 
 ENV LANG C.UTF-8
 
-RUN apt-get update \
- && apt-get install -y libgl1-mesa-glx
+RUN install_packages libgl1-mesa-glx
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
By this, the extended base image ends up with only 60MB.