### PR TITLE
locale-gen en_US.UTF-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM bitnami/minideb:jessie
 MAINTAINER johanneskoester "johannes.koester@tu-dortmund.de"
 
-ENV LC_ALL=C.UTF-8
-    LANG=C.UTF-8
-
 # By default en_US.UTF-8 is not generated, and locale-gen is not installed
 # (comes with locales)
 RUN install_packages libgl1-mesa-glx locales
 
 # Uncomment the en_US.UTF-8 line from /etc/locale.gen and regenerate
 RUN sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen && locale-gen
+
+ENV LC_ALL=en_US.UTF-8
+    LANG=en_US.UTF-8
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
 FROM bitnami/minideb:jessie
 MAINTAINER johanneskoester "johannes.koester@tu-dortmund.de"
 
-ENV LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8
+ENV LC_ALL=C.UTF-8
+    LANG=C.UTF-8
 
-RUN install_packages libgl1-mesa-glx
+# By default en_US.UTF-8 is not generated, and locale-gen is not installed
+# (comes with locales)
+RUN install_packages libgl1-mesa-glx locales
+
+# Uncomment the en_US.UTF-8 line from /etc/locale.gen and regenerate
+RUN sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen && locale-gen
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Install locale-gen, generate the en_US.UTF-8 locale, and set to the default. This aligns the installed locales with those available in the condaforge/linux-anvil container.

xref https://github.com/bioconda/bioconda-recipes/pull/6094