### PR TITLE
fix: typo in locale ENV export

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN install_packages libgl1-mesa-glx locales
 # Uncomment the en_US.UTF-8 line from /etc/locale.gen and regenerate
 RUN sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen && locale-gen
 
-ENV LC_ALL=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Docker image did not successfully build.
See: https://hub.docker.com/r/bioconda/extended-base-image/builds/
There was a syntactical error at locale environment variable export.