### PR TITLE
Update to buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM bitnami/minideb:jessie
+FROM bitnami/minideb:buster
 MAINTAINER johanneskoester "johannes.koester@tu-dortmund.de"
 
 # By default en_US.UTF-8 is not generated, and locale-gen is not installed
 # (comes with locales)
 # and uncomment the en_US.UTF-8 line from /etc/locale.gen and regenerate
-RUN install_packages libgl1-mesa-glx locales openssh-client procps && \
+RUN install_packages libglx-mesa0 locales openssh-client procps && \
     sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen && locale-gen
 
 ENV LC_ALL=en_US.UTF-8 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM bitnami/minideb:buster
+FROM bitnami/minideb:stretch
 MAINTAINER johanneskoester "johannes.koester@tu-dortmund.de"
 
 # By default en_US.UTF-8 is not generated, and locale-gen is not installed
 # (comes with locales)
 # and uncomment the en_US.UTF-8 line from /etc/locale.gen and regenerate
-RUN install_packages libglx-mesa0 locales openssh-client procps && \
+RUN install_packages libgl1-mesa-glx locales openssh-client procps && \
     sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen && locale-gen
 
 ENV LC_ALL=en_US.UTF-8 \


### PR DESCRIPTION
Address issue #9 

A caveat: this hasn't been CI'd against all bioconda packages that use the extended base image.

Also, note that for buster, the libglx-mesa0 package (apparently replacing the now "dummy" libgl1-mesa-glx package) has more dependency bloat, over doubling the size of the resulting Docker image compared to jessie & stretch.